### PR TITLE
Implementatie of het cc_status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## Requirements
 - Python > 3.6
 - virtualenv
+- MQTT broker (for example Mosquitto)
 
-## Installation
-
+## Installatie
 ```bash
 # Create an isolated environment
 virtualenv --no-site-packages -p $(which python3) venv
@@ -21,4 +21,11 @@ python setup.py develop
 
 # Start server
 venv/bin/pserve serve development.ini
+```
+
+## MQTT
+Om gebruik te maken van een lokale MQTT broker kunnen de volgende instellingen in `development.ini` aangepast worden:
+```bash
+mqtt.hostname = localhost
+mqtt.port = 1883
 ```

--- a/central_server/__init__.py
+++ b/central_server/__init__.py
@@ -1,13 +1,10 @@
-import os
 import logging
 
 from pyramid.config import Configurator
 from central_server import views
 
 logging.basicConfig()
-log = logging.getLogger('waitress')
-
-here = os.path.dirname(os.path.abspath(__file__))
+log = logging.getLogger('central_server')
 
 
 def main(global_config, **settings):
@@ -22,10 +19,10 @@ def main(global_config, **settings):
 
     # Configure routes
     config.scan()
-    config.add_route('home', '/')
-    config.add_route('cc_home', '/cc/{id}')
-    config.add_route('cc_status', '/cc/{id}/status')
-    config.add_route('cc_move', '/cc/{id}/move')
+    config.add_route('home', '/', request_method='GET')
+    config.add_route('cc_home', '/cc/{id}', request_method='GET')
+    config.add_route('cc_status', '/cc/{id}/status', request_method='GET')
+    config.add_route('cc_move', '/cc/{id}/move', request_method='POST')
 
     # serve central_server
     return config.make_wsgi_app()

--- a/central_server/__init__.py
+++ b/central_server/__init__.py
@@ -4,7 +4,6 @@ from pyramid.config import Configurator
 from central_server import views
 
 logging.basicConfig()
-log = logging.getLogger('central_server')
 
 
 def main(global_config, **settings):

--- a/central_server/views/cc_home_status.py
+++ b/central_server/views/cc_home_status.py
@@ -1,12 +1,58 @@
+import time
+import logging
+from pyramid.httpexceptions import (HTTPGatewayTimeout, HTTPInternalServerError)
 from pyramid.view import (view_config)
-from paho.mqtt.subscribe import (simple)
-from paho.mqtt.publish import (single)
+import paho.mqtt.client as mqtt
+
+log = logging.getLogger("view.cc_home_status")
 
 
 @view_config(route_name='cc_status', renderer='json')
 def cc_status_view(request):
-    cc_id = request.matchdict['id']
+    global loop
+    global status
 
-    return {
-        'id': cc_id
-    }
+    loop = True
+    status = None
+
+    # The callback for when the client receives a CONNACK response from the server.
+    def on_connect(client, userdata, flags, rc):
+        client.subscribe(topic='cc/' + request.matchdict['id'] + '/status', qos=1)
+        client.publish(topic='cc/' + request.matchdict['id'] + '/cmd', payload='request_status', qos=1)
+
+    # The callback for when a PUBLISH message is received from the server.
+    def on_message(client, userdata, msg):
+        global loop
+        global status
+
+        status = msg.payload.decode("utf-8")
+        loop = False
+
+    client = mqtt.Client("server")
+    client.on_connect = on_connect
+    client.on_message = on_message
+
+    try:
+        client.connect(request.registry.settings["mqtt.hostname"], int(request.registry.settings["mqtt.port"]), 60)
+    except ConnectionError as e:
+        log.error("Error when connecting to the MQTT broker: %s", e)
+        raise HTTPInternalServerError
+
+    start_time = time.time()
+
+    # Wait 30 seconds for a response
+    while loop:
+        client.loop()
+        elapsed_time = time.time() - start_time
+
+        if elapsed_time > 30:
+            client.disconnect()
+            loop = False
+            break
+
+    if status is None:
+        raise HTTPGatewayTimeout
+    else:
+        return {
+            'status': status
+        }

--- a/central_server/views/cc_home_status.py
+++ b/central_server/views/cc_home_status.py
@@ -18,7 +18,7 @@ def cc_status_view(request):
     # The callback for when the client receives a CONNACK response from the server.
     def on_connect(client, userdata, flags, rc):
         client.subscribe(topic='cc/' + request.matchdict['id'] + '/status', qos=1)
-        client.publish(topic='cc/' + request.matchdict['id'] + '/cmd', payload='request_status', qos=1)
+        client.publish(topic='cc/' + request.matchdict['id'] + '/cmd', payload='{"cmd": "request_status", "payload": ""}', qos=1)
 
     # The callback for when a PUBLISH message is received from the server.
     def on_message(client, userdata, msg):

--- a/central_server/views/cc_home_status.py
+++ b/central_server/views/cc_home_status.py
@@ -1,14 +1,12 @@
 from pyramid.view import (view_config)
-from pyramid.httpexceptions import (HTTPMethodNotAllowed)
+from paho.mqtt.subscribe import (simple)
+from paho.mqtt.publish import (single)
 
 
 @view_config(route_name='cc_status', renderer='json')
 def cc_status_view(request):
-    if request.method == 'GET':
-        cc_id = request.matchdict['id']
+    cc_id = request.matchdict['id']
 
-        return {
-            'id': cc_id
-        }
-
-    raise HTTPMethodNotAllowed
+    return {
+        'id': cc_id
+    }

--- a/central_server/views/cc_home_view.py
+++ b/central_server/views/cc_home_view.py
@@ -1,12 +1,8 @@
 from pyramid.view import (view_config)
-from pyramid.httpexceptions import (HTTPMethodNotAllowed)
 
 
 @view_config(route_name='cc_home', renderer='cc_home.mako')
 def cc_home_view(request):
-    if request.method == 'GET':
-        return {
-            'id': request.matchdict['id']
-        }
-
-    raise HTTPMethodNotAllowed
+    return {
+        'id': request.matchdict['id']
+    }

--- a/central_server/views/cc_move.py
+++ b/central_server/views/cc_move.py
@@ -1,19 +1,16 @@
 from pyramid.view import (view_config)
-from pyramid.httpexceptions import (HTTPBadRequest, HTTPMethodNotAllowed)
+from pyramid.httpexceptions import (HTTPBadRequest)
 
 
 @view_config(route_name='cc_move', renderer='json')
 def cc_move(request):
-    if request.method == 'POST':
-        if request.json_body.get('setup'):
-            cc_id = request.matchdict['id']
-            setup = request.json_body['setup']
+    if request.json_body.get('setup'):
+        cc_id = request.matchdict['id']
+        setup = request.json_body['setup']
 
-            return {
-                'id': cc_id,
-                'setup': setup
-            }
-        else:
-            raise HTTPBadRequest
-
-    raise HTTPMethodNotAllowed
+        return {
+            'id': cc_id,
+            'setup': setup
+        }
+    else:
+        raise HTTPBadRequest

--- a/central_server/views/home_view.py
+++ b/central_server/views/home_view.py
@@ -1,10 +1,6 @@
 from pyramid.view import (view_config)
-from pyramid.httpexceptions import (HTTPMethodNotAllowed)
 
 
 @view_config(route_name='home', renderer='home.mako')
 def home_view(request):
-    if request.method == 'GET':
-        return {}
-
-    raise HTTPMethodNotAllowed
+    return {}

--- a/development.ini
+++ b/development.ini
@@ -1,11 +1,15 @@
 [app:main]
 use = egg:central_server
 
+mqtt.hostname = localhost
+mqtt.port = 1883
+
 pyramid.reload_templates = true
 pyramid.debug_authorization = false
 pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.debug_templates = true
+
 mako.directories = central_server:templates
 
 [server:main]


### PR DESCRIPTION
Deze PR is voor issue #2 

## Samenvatting
Deze PR is de implementatie van het `cc/{id}/status` endpoint. Via dit endpoint kan de status van een control center opgevraagd worden. Het resultaat is bijvoorbeeld: `busy`, `available`.

Het opvragen van de status gebeurd via het topic `cc/{id}/cmd` met een commando in JSON format `{"cmd": "request_status", "payload": ""}`. Het control center reageert hierop met een publish op het topic `cc/{id}/status`

## Testen
Het testen van dit endpoint kan door het uitvoeren van het onderstaande script **gelijktijdig** met het draaien van de server. Gebruik voor het testen het ednpoint: http://localhost:8080/cc/5/status. De status verwachte response is:
```json
{
    "status": "available"
}
```

test.py
```py
import paho.mqtt.client as mqtt
import json


# The callback for when the client receives a CONNACK response from the server.
def on_connect(client, userdata, flags, rc):
    print("Connected with result code "+str(rc))

    # Subscribing in on_connect() means that if we lose the connection and
    # reconnect then subscriptions will be renewed.
    client.subscribe("cc/5/cmd")


# The callback for when a PUBLISH message is received from the server.
def on_message(client, userdata, msg):
    msg = msg.payload.decode("utf-8")

    if json.loads(msg)['cmd'] == 'request_status':
        client.publish("cc/5/status", "available")


client = mqtt.Client()
client.on_connect = on_connect
client.on_message = on_message

client.connect("localhost", 1883, 60)

# Blocking call that processes network traffic, dispatches callbacks and
# handles reconnecting.
# Other loop*() functions are available that give a threaded interface and a
# manual interface.
client.loop_forever()
```